### PR TITLE
Use assert() to report errors

### DIFF
--- a/assembly/decoder.ts
+++ b/assembly/decoder.ts
@@ -43,10 +43,10 @@ export class BSONDecoder<BSONHandlerT extends BSONHandler> {
     }
 
     deserialize(buffer: Uint8Array, i: i32 = 0): void {
-        assert(buffer.length > 5, "Document error: Size < 5 bytes");
+        assert(buffer.length >= 5, "Document error: Size < 5 bytes");
 
         let size : i32 = buffer[i++] | i32(buffer[i++]) << 8 | i32(buffer[i++]) << 16 | i32(buffer[i++]) << 24;
-        assert(size > 5 && size <= buffer.length, "Document error: Size mismatch");
+        assert(size <= buffer.length, "Document error: Size mismatch");
         assert(buffer[buffer.length - 1] == 0x00, "Document error: Missing termination");
 
         for (; ;) {

--- a/assembly/decoder.ts
+++ b/assembly/decoder.ts
@@ -43,21 +43,11 @@ export class BSONDecoder<BSONHandlerT extends BSONHandler> {
     }
 
     deserialize(buffer: Uint8Array, i: i32 = 0): void {
-        // check size
-        if (buffer.length < 5) {
-            // TODO: Report errors instead of just returning
-            // Document error: Size < 5 bytes
-            return;
-        }
+        assert(buffer.length > 5, "Document error: Size < 5 bytes");
+
         let size : i32 = buffer[i++] | i32(buffer[i++]) << 8 | i32(buffer[i++]) << 16 | i32(buffer[i++]) << 24;
-        if (size < 5 || size > buffer.length) {
-            // Document error: Size mismatch
-            return;
-        }
-        if (buffer[buffer.length - 1] !== 0x00) {
-            // Document error: Missing termination
-            return;
-        }
+        assert(size > 5 && size <= buffer.length, "Document error: Size mismatch");
+        assert(buffer[buffer.length - 1] == 0x00, "Document error: Missing termination");
 
         for (; ;) {
             // get element type
@@ -67,10 +57,7 @@ export class BSONDecoder<BSONHandlerT extends BSONHandler> {
             // get element name
             let end = i;
             for (; buffer[end] !== 0x00 && end < buffer.length; end++);
-            if (end >= buffer.length - 1) {
-                // Document error: Illegal key name
-                return;
-            }
+            assert(end < buffer.length - 1, "Document error: Illegal key name");
             let name = bin2str(buffer.subarray(i, end));
             i = ++end;                      // skip terminating zero
 
@@ -121,8 +108,7 @@ export class BSONDecoder<BSONHandlerT extends BSONHandler> {
                     break;
 
                 default:
-                    // Parsing error: Unknown element
-                    return;
+                    assert(false, "Parsing error: Unknown element");
             }
         }
     }

--- a/tests/assembly/decoder.spec.as.ts
+++ b/tests/assembly/decoder.spec.as.ts
@@ -225,33 +225,27 @@ export class StringConversionTests {
     }
     */
   
-    static shouldCheckDocumentTooSmall(): bool {
+    static shouldAbortDocumentTooSmall(): void {
         this.createDecoder().deserialize(hex2bin("04000000"));
-        return handler.events.length == 0;
     }
   
-    static shouldCheckDocumentTermination1() : bool {
+    static shouldAbortDocumentTermination1(): void {
         this.createDecoder().deserialize(hex2bin("0c00000008626f6f6c000001"));
-        return handler.events.length == 0;
     }
-    static shouldCheckDocumentTermination2() : bool {
+    static shouldAbortDocumentTermination2(): void {
         this.createDecoder().deserialize(hex2bin("0c00000008626f6f6c0000"));
-        return handler.events.length == 0;
     }
   
-    static shouldCheckDocumentSizeMismatch() : bool {
+    static shouldAbortDocumentSizeMismatch(): void {
         this.createDecoder().deserialize(hex2bin("0d00000008626f6f6c000000"));
-        return handler.events.length == 0;
     }
   
-    static shouldCheckIllegalKeyname() : bool {
+    static shouldAbortIllegalKeyname(): void {
         this.createDecoder().deserialize(hex2bin("0c00000008626f6f6c010100"));
-        return handler.events.length == 0;
     }
   
-    static shouldCheckUnknownElement() : bool {
+    static shouldAbortUnknownElement(): void {
         this.createDecoder().deserialize(hex2bin("0c00000018626f6f6c000000"));
-        return handler.events.length == 0;
     }
 }
 

--- a/tests/decoder.spec.ts
+++ b/tests/decoder.spec.ts
@@ -1,35 +1,3 @@
-import test from 'ava';
-import { setup, decamelize, isThrowable } from './utils/helpers';
+import { defineTestsFromModule } from './utils/spec';
 
-(async () => {
-  try {
-    const instance = await setup('decoder');
-  } catch (e) {
-    console.log("Error loading WebAssembly module:", e);
-    throw e;
-  }
-
-  // TODO: Refactor into proper testing framework for AssemblyScript
-  for (const tests in instance) {
-    const testsInstance = instance[tests];
-    if (isThrowable(tests)) {
-      for (const testName in testsInstance) {
-        test(decamelize(testName), t => t.throws(() => testsInstance[testName]()));
-      }
-    } else {
-      if (testsInstance.setUp) {
-        test.beforeEach(() => {
-          testsInstance.setUp();
-        });
-      }
-      if (testsInstance.tearDown) {
-        test.afterEach(() => {
-          testsInstance.tearDown();
-        });
-      }
-      for (const testName of Object.keys(testsInstance).filter(it => !(["setUp", "tearDown"].indexOf(it) != -1))) {
-        test(decamelize(testName), t => t.truthy(testsInstance[testName]()));
-      }
-    }
-  }
-})();
+defineTestsFromModule('decoder');

--- a/tests/encoder.spec.ts
+++ b/tests/encoder.spec.ts
@@ -1,35 +1,3 @@
-import test from 'ava';
-import { setup, decamelize, isThrowable } from './utils/helpers';
+import { defineTestsFromModule } from './utils/spec';
 
-(async () => {
-  try {
-    const instance = await setup('encoder');
-  } catch (e) {
-    console.log("Error loading WebAssembly module:", e);
-    throw e;
-  }
-
-  // TODO: Refactor into proper testing framework for AssemblyScript
-  for (const tests in instance) {
-    const testsInstance = instance[tests];
-    if (isThrowable(tests)) {
-      for (const testName in testsInstance) {
-        test(decamelize(testName), t => t.throws(() => testsInstance[testName]()));
-      }
-    } else {
-      if (testsInstance.setUp) {
-        test.beforeEach(() => {
-          testsInstance.setUp();
-        });
-      }
-      if (testsInstance.tearDown) {
-        test.afterEach(() => {
-          testsInstance.tearDown();
-        });
-      }
-      for (const testName of Object.keys(testsInstance).filter(it => !(["setUp", "tearDown"].indexOf(it) != -1))) {
-        test(decamelize(testName), t => t.truthy(testsInstance[testName]()));
-      }
-    }
-  }
-})();
+defineTestsFromModule('encoder');

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -18,10 +18,6 @@ const readFile = util.promisify(fs.readFile);
 const F64 = new Float64Array(1);
 const U64 = new Uint32Array(F64.buffer);
 
-export function isThrowable(name: string): boolean {
-  return name.toLowerCase().includes('throwable');
-}
-
 export function decamelize(str: string): string {
   const t = str
     .replace(DIGITALS_REGEXP, ' $1')

--- a/tests/utils/spec.ts
+++ b/tests/utils/spec.ts
@@ -1,0 +1,34 @@
+import test from 'ava';
+import { setup, decamelize } from './helpers';
+
+export async function defineTestsFromModule(moduleName: string) {
+  try {
+    const instance = await setup(moduleName);
+
+    // TODO: Refactor into proper testing framework for AssemblyScript
+    for (const tests in instance) {
+        const testsInstance = instance[tests];
+
+        if (testsInstance.setUp) {
+            test.beforeEach(() => {
+                testsInstance.setUp();
+            });
+        }
+        if (testsInstance.tearDown) {
+            test.afterEach(() => {
+                testsInstance.tearDown();
+            });
+        }
+        for (const testName of Object.keys(testsInstance).filter(it => !(["setUp", "tearDown"].indexOf(it) != -1))) {
+            if (testName.startsWith("shouldAbort")) {  
+                test(decamelize(testName), t => { t.throws(() => testsInstance[testName]()) });
+            } else {
+                test(decamelize(testName), t => t.truthy(testsInstance[testName]()));
+            }
+        }
+    }
+  } catch (e) {
+    console.log("Error loading WebAssembly module:", e);
+    throw e;
+  }
+};


### PR DESCRIPTION
This means that parser will trigger `abort` instead of silently ignoring errors.

TODO:
- [x] Fix tests
- [ ] Make this behavior a config option